### PR TITLE
feat: use fetch by switch to xior from axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "cboard-ai-engine",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cboard-ai-engine",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "axios": "^1.6.2",
         "nanoid": "^5.0.6",
-        "openai": "^3.3.0"
+        "openai": "^3.3.0",
+        "xior": "^0.1.3"
       },
       "devDependencies": {
         "ts-node": "^10.9.2",
@@ -801,16 +801,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1678,11 +1668,6 @@
         }
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1994,6 +1979,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-lru": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.2.5.tgz",
+      "integrity": "sha512-JpqM0K33lG6iQGKiigcwuURAKZlq6rHXfrgeL4/I8/REoyJTGU+tEMszvT/oTRVHG2OiylhGDjqPp1jWMlr3bw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2022,6 +2015,14 @@
       "dev": true,
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-deepmerge": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.0.tgz",
+      "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA==",
+      "engines": {
+        "node": ">=14.13.1"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -2269,6 +2270,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xior": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/xior/-/xior-0.1.3.tgz",
+      "integrity": "sha512-0MldWDW5eqG/5Md6CdV0+Lky8ktNQEuJJIrPk9/6JHXK0OKKFNyS+ZhYYD7wLK/Ne8okzV0otd7gXRrBrAkRng==",
+      "dependencies": {
+        "tiny-lru": "^11.2.5",
+        "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Cboard-org",
   "license": "GPL-3.0-only",
   "dependencies": {
-    "axios": "^1.6.2",
+    "xior": "^0.1.3",
     "nanoid": "^5.0.6",
     "openai": "^3.3.0"
   },

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,8 +1,10 @@
 import { Configuration, OpenAIApi, ConfigurationParameters } from "openai";
-import axios, { AxiosRequestConfig } from "axios";
+import xior from "xior";
 import { DEFAULT_GLOBAL_SYMBOLS_URL, DEFAULT_LANGUAGE, DEFAULT_MAX_SUGGESTIONS } from "./constants";
 import { LabelsSearchApiResponse } from "./types/global-symbols";
 import { nanoid } from "nanoid";
+
+const axios = xior.create();
 
 const globalConfiguration = {
   openAIInstance: {} as OpenAIApi,
@@ -122,7 +124,7 @@ async function fetchPictogramsURLs({
           symbolset: symbolSet,
           language: language,
         },
-      } as AxiosRequestConfig)
+      })
     );
     const responses = await Promise.all(requests);
 


### PR DESCRIPTION
Since node 18 already support fetch API,  so we can use fetch now and `xior` is based on fetch and similar axios API.

**Befenits**:

- Support edge runtime
- Get smaller size
- Close issue https://github.com/cboard-org/cboard-ai-engine/issues/2