### PR TITLE
Fixed issues to prevent 404 error in getting pictogram from Arasaac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cboard-ai-engine",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cboard-ai-engine",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@azure-rest/ai-content-safety": "^1.0.0",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -92,8 +92,9 @@ async function getWordSuggestions({
     prompt: `act as a speech pathologist selecting pictograms in language ${languageName} 
       for a non verbal person about ${prompt}. 
       Here are mandatory instructions for the list:
-        -Provide a list containing a maximum of ${maxWords} words.
-        -When using verbs you must use infinitive form. Do not use gerunds, conjugated forms, or any other variations of the verb. 
+        -Ensure that the list contains precisely ${maxWords} words; it must not be shorter or longer.
+        -The words should be related to the topic.
+        -When using verbs, you must use the infinitive form. Do not use gerunds, conjugated forms, or any other variations of the verb. 
         -Do not repeat any words.
         -Do not include any additional text, symbols, or characters beyond the words requested.
         -The list should follow this exact format: {word1, word2, word3,..., wordN}.`,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -35,7 +35,7 @@ export type Suggestion = {
           id: string;
           symbolSet: string;
           url: string;
-        }[]
+        }[];
   };
 };
 
@@ -88,15 +88,15 @@ async function getWordSuggestions({
   const languageName = getLanguageName(language);
   const max_tokens = Math.round(4.2 * maxWords + 110);
   const completionRequestParams = {
-    model: "gpt-3.5-turbo-instruct", 
+    model: "gpt-3.5-turbo-instruct",
     prompt: `act as a speech pathologist selecting pictograms in language ${languageName} 
       for a non verbal person about ${prompt}. 
       Here are mandatory instructions for the list:
-        -You must provide a list of ${maxWords} maximum.
-        -If you use verb, just use inifinitive form, not gerunds
-        -It is very important to not repeat words. 
-        -Do not add any other text or characters to the list. 
-        -Template for the list {word1, word2, word3,..., wordN}`,
+        -Provide a list containing a maximum of ${maxWords} words.
+        -When using verbs you must use infinitive form. Do not use gerunds, conjugated forms, or any other variations of the verb. 
+        -Do not repeat any words.
+        -Do not include any additional text, symbols, or characters beyond the words requested.
+        -The list should follow this exact format: {word1, word2, word3,..., wordN}.`,
     temperature: 0,
     max_tokens: max_tokens,
   };
@@ -125,7 +125,7 @@ async function fetchPictogramsURLs({
   words,
   language,
   symbolSet = ARASAAC,
-  globalSymbolsSymbolSet
+  globalSymbolsSymbolSet,
 }: {
   words: string[];
   language: string;
@@ -166,13 +166,12 @@ async function getSuggestions({
     maxWords: maxSuggestions,
     language,
   });
-  const suggestions: Suggestion[] =
-    await fetchPictogramsURLs({
-      words,
-      language,
-      symbolSet,
-      globalSymbolsSymbolSet
-    });
+  const suggestions: Suggestion[] = await fetchPictogramsURLs({
+    words,
+    language,
+    symbolSet,
+    globalSymbolsSymbolSet,
+  });
 
   return suggestions;
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -93,7 +93,6 @@ async function getWordSuggestions({
       for a non verbal person about ${prompt}. 
       Here are mandatory instructions for the list:
         -You must provide a list of ${maxWords} maximum.
-        -Only include infinitive verbs, do not include any gerunds (verbs ending in -ing).
         -It is very important to not repeat words. 
         -Do not add any other text or characters to the list. 
         -Template for the list {word1, word2, word3,..., wordN}`,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -93,6 +93,7 @@ async function getWordSuggestions({
       for a non verbal person about ${prompt}. 
       Here are mandatory instructions for the list:
         -You must provide a list of ${maxWords} maximum.
+        -If you use verb, just use inifinitive form, not gerunds
         -It is very important to not repeat words. 
         -Do not add any other text or characters to the list. 
         -Template for the list {word1, word2, word3,..., wordN}`,

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -93,6 +93,7 @@ async function getWordSuggestions({
       for a non verbal person about ${prompt}. 
       Here are mandatory instructions for the list:
         -You must provide a list of ${maxWords} maximum.
+        -Only include infinitive verbs, do not include any gerunds (verbs ending in -ing).
         -It is very important to not repeat words. 
         -Do not add any other text or characters to the list. 
         -Template for the list {word1, word2, word3,..., wordN}`,

--- a/src/lib/symbolSets.ts
+++ b/src/lib/symbolSets.ts
@@ -59,7 +59,8 @@ async function fetchArasaacData(URL: string, word: string, language: string) {
     return data;
   } catch {
     try {
-      const { data } = await axios.get<BestSearchApiResponse>(searchUrl);
+      let { data } = await axios.get<BestSearchApiResponse>(searchUrl);
+      if (data.length > 5) data = data.slice(0, 5);
       return data;
     } catch {
       return [];

--- a/src/lib/symbolSets.ts
+++ b/src/lib/symbolSets.ts
@@ -19,9 +19,9 @@ export async function getArasaacPictogramSuggestions({
 }) {
   const responses = await Promise.all(
     words.map(async (word) => {
-      const fullUrl = `${URL}/${language}/bestsearch/${encodeURIComponent(
-        removeDiacritics(word)
-      )}`;
+      const fullUrl = word.includes(" ")
+      ? `${URL}/${language}/search/${encodeURIComponent(removeDiacritics(word))}`
+      : `${URL}/${language}/bestsearch/${encodeURIComponent(removeDiacritics(word))}`;
       return axios
         .get<BestSearchApiResponse>(fullUrl)
         .then((response) => response.data)

--- a/src/lib/symbolSets.ts
+++ b/src/lib/symbolSets.ts
@@ -1,102 +1,14 @@
-import axios from "axios";
-import { AxiosRequestConfig } from "axios";
-import { LabelsSearchApiResponse } from "../types/global-symbols";
-import { Suggestion } from "../engine";
+import axios, { AxiosRequestConfig } from "axios";
 import { nanoid } from "nanoid";
+import { LabelsSearchApiResponse } from "../types/global-symbols";
 import { BestSearchApiResponse } from "../types/arasaac";
+import { Suggestion } from "../engine";
 import { ARASAAC } from "../constants";
 
 export type SymbolSet = "arasaac" | "global-symbols";
 
-export async function getArasaacPictogramSuggestions({
-  URL,
-  words,
-  language,
-}: {
-  URL: string;
-  words: string[];
-  language: string;
-}) {
-  const responses = await Promise.all(
-    words.map(async (word) => {
-      const fullUrl = word.includes(" ")
-      ? `${URL}/${language}/search/${encodeURIComponent(removeDiacritics(word))}`
-      : `${URL}/${language}/bestsearch/${encodeURIComponent(removeDiacritics(word))}`;
-      return axios
-        .get<BestSearchApiResponse>(fullUrl)
-        .then((response) => response.data)
-        .catch((error: unknown) => {
-          return [];
-        });
-    })
-  );
-  const suggestions: Suggestion[] = responses.map((data) => {
-    const label = words[responses.indexOf(data)];
-    if (data && !!data.length)
-      return {
-        id: nanoid(5),
-        label: label,
-        locale: language,
-        pictogram: {
-          images: data.map((pictogram: any) => ({
-            id: pictogram._id,
-            symbolSet: ARASAAC,
-            url: `https://static.arasaac.org/pictograms/${pictogram._id}/${pictogram._id}_500.png`,
-          })),
-        },
-      };
-    return getEmptyImageSuggestion(label, language);
-  });
-  return suggestions;
-}
-
-export async function getGlobalSymbolsPictogramSuggestions({
-  URL,
-  words,
-  language,
-  symbolSet,
-}: {
-  URL: string;
-  words: string[];
-  language: string;
-  symbolSet: string | null;
-}) {
-  const responses = await Promise.all(
-    words.map((word) =>
-      axios
-        .get<LabelsSearchApiResponse>(URL, {
-          params: {
-            query: removeDiacritics(word),
-            symbolset: symbolSet || null,
-            language: language,
-            language_iso_format: "639-1",
-          },
-        } as AxiosRequestConfig)
-        .then((response) => response.data)
-        .catch((error: unknown) => {
-          return [];
-        })
-    )
-  );
-
-  const suggestions: Suggestion[] = responses.map((data) => {
-    const label = words[responses.indexOf(data)];
-    if (data && !!data.length)
-      return {
-        id: nanoid(5),
-        label: label,
-        locale: data[0].language,
-        pictogram: {
-          images: data.map((label) => ({
-            id: label.id.toString(),
-            symbolSet: label.picto.symbolset_id.toString(),
-            url: label.picto.image_url,
-          })),
-        },
-      };
-    return getEmptyImageSuggestion(label, language);
-  });
-  return suggestions;
+function removeDiacritics(str: string) {
+  return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 }
 
 function getEmptyImageSuggestion(word: string, language: string): Suggestion {
@@ -116,6 +28,130 @@ function getEmptyImageSuggestion(word: string, language: string): Suggestion {
   };
 }
 
-function removeDiacritics(str: string) {
-  return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+export async function getArasaacPictogramSuggestions({
+  URL,
+  words,
+  language,
+}: {
+  URL: string;
+  words: string[];
+  language: string;
+}): Promise<Suggestion[]> {
+  const requests = words.map((word) => fetchArasaacData(URL, word, language));
+  const responses = await Promise.all(requests);
+
+  return words.map((word, index) =>
+    mapArasaacResponse(word, language, responses[index])
+  );
+}
+
+async function fetchArasaacData(URL: string, word: string, language: string) {
+  const cleanedWord = removeDiacritics(word);
+  const bestSearchUrl = `${URL}/${language}/bestsearch/${encodeURIComponent(
+    cleanedWord
+  )}`;
+  const searchUrl = `${URL}/${language}/search/${encodeURIComponent(
+    cleanedWord
+  )}`;
+
+  try {
+    const { data } = await axios.get<BestSearchApiResponse>(bestSearchUrl);
+    return data;
+  } catch {
+    try {
+      const { data } = await axios.get<BestSearchApiResponse>(searchUrl);
+      return data;
+    } catch {
+      return [];
+    }
+  }
+}
+
+function mapArasaacResponse(
+  word: string,
+  language: string,
+  data: BestSearchApiResponse | []
+): Suggestion {
+  if (data && data.length) {
+    return {
+      id: nanoid(5),
+      label: word,
+      locale: language,
+      pictogram: {
+        images: data.map((pictogram) => ({
+          id: pictogram._id.toString(),
+          symbolSet: ARASAAC,
+          url: `https://static.arasaac.org/pictograms/${pictogram._id}/${pictogram._id}_500.png`,
+        })),
+      },
+    };
+  }
+  return getEmptyImageSuggestion(word, language);
+}
+
+export async function getGlobalSymbolsPictogramSuggestions({
+  URL,
+  words,
+  language,
+  symbolSet,
+}: {
+  URL: string;
+  words: string[];
+  language: string;
+  symbolSet: string | null;
+}): Promise<Suggestion[]> {
+  const requests = words.map((word) =>
+    fetchGlobalSymbolsData(URL, word, language, symbolSet)
+  );
+  const responses = await Promise.all(requests);
+
+  return words.map((word, index) =>
+    mapGlobalSymbolsResponse(word, language, responses[index])
+  );
+}
+
+async function fetchGlobalSymbolsData(
+  URL: string,
+  word: string,
+  language: string,
+  symbolSet: string | null
+) {
+  const cleanedWord = removeDiacritics(word);
+  const config: AxiosRequestConfig = {
+    params: {
+      query: cleanedWord,
+      symbolset: symbolSet || null,
+      language: language,
+      language_iso_format: "639-1",
+    },
+  };
+
+  try {
+    const { data } = await axios.get<LabelsSearchApiResponse>(URL, config);
+    return data;
+  } catch {
+    return [];
+  }
+}
+
+function mapGlobalSymbolsResponse(
+  word: string,
+  language: string,
+  data: LabelsSearchApiResponse | []
+): Suggestion {
+  if (data && data.length) {
+    return {
+      id: nanoid(5),
+      label: word,
+      locale: data[0].language,
+      pictogram: {
+        images: data.map((label) => ({
+          id: label.id.toString(),
+          symbolSet: label.picto.symbolset_id.toString(),
+          url: label.picto.image_url,
+        })),
+      },
+    };
+  }
+  return getEmptyImageSuggestion(word, language);
 }


### PR DESCRIPTION
- Added a clarification to the prompt for ChatGPT: "If you use verbs, use the infinitive form, not gerunds" to ensure word suggestions avoid gerunds.
- Implemented the use of the Arasaac search endpoint for terms consisting of two words.(bestsearch endpoint returns well for terms consisting of one word)