### PR TITLE
Pictogram

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -86,13 +86,14 @@ async function getWordSuggestions({
   language: string;
 }): Promise<string[]> {
   const languageName = getLanguageName(language);
-  const max_tokens = Math.round(4.2 * maxWords * 2 + 110);
+  const max_tokens = Math.round(4.2 * maxWords + 110);
   const completionRequestParams = {
     model: "gpt-3.5-turbo-instruct",
     prompt: `act as a speech pathologist selecting pictograms in language ${languageName} 
       for a non verbal person about ${prompt}. 
       Here are mandatory instructions for the list:
         -You must provide a list of ${maxWords} maximum.
+        -When using verbs you must use infinitive form. Do not use gerunds, conjugated forms, or any other variations of the verb. 
         -It is very important to not repeat words. 
         -Do not add any other text or characters to the list. 
         -Template for the list {word1, word2, word3,..., wordN}`,


### PR DESCRIPTION
I've updated ARASSAC Pictogram Fetching Logic and reverted prompt to v1.4.
For this implementation, I tried the following logic.
- I've doubled maximum words for fetching labels. ex: User requested 20 Pictograms, then new logic fetchs 40 words from GPT.
- Then I check each words if it has valid Pictograms using ARASSAC API until the number of valid words reaches 20, looping 40 words. 
- In case 20 of 40 words doesn't have available pictograms, for example, checking 40 words, 15 words have Pictogram, then I add 5 unavailable words from 40 words choosen. But this is unlikely happening.
- Once the array of 20 words is ready, I fetched pictogram data from ARASSAC.

close #50