### PR TITLE
Filter arrasac pictograms with nsfw

### DIFF
--- a/src/lib/symbolSets.ts
+++ b/src/lib/symbolSets.ts
@@ -60,6 +60,7 @@ async function fetchArasaacData(URL: string, word: string, language: string) {
   } catch {
     try {
       let { data } = await axios.get<BestSearchApiResponse>(searchUrl);
+      data = data.filter((item)=>!item.sex && !item.violence)
       if (data.length > 5) data = data.slice(0, 5);
       return data;
     } catch {


### PR DESCRIPTION
Filter NSFW content from Arrasac Pictograms fetched using key word.
Tested with word "Practice" and the result is positive.
There were about 10 pictograms including NSFW content but some of them had "sex" and "violence" index as true.
I filtered only pictograms whose "sex" and "violence" index are false.

close #54 